### PR TITLE
Add "Status" and other results fields. Limit search results to current site for WP multisite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ This way it's in the correct folder and you can update the plugin by going to th
 directory and use git pull to obtain the latest version.
 
 Don't forget to activate the plugin through the 'Plugins' menu in WordPress
+
+**Permissions**
+
+Roles that have the `list_users` capability can access the search page. Alternatively, users with the custom `as_em_search` capability can access the search page. (The plugin does not add or remove this custom capability, but checks for it. You can add it using WP-CLI or a role editor plugin.)

--- a/as-em-search.php
+++ b/as-em-search.php
@@ -11,8 +11,8 @@
  *
  * @wordpress-plugin
  * Plugin Name:       AS EM Search
- * Description:       Makes it possible to search in bookings and events
- * Version:           1.1.0
+ * Description:       Makes it possible to search in Events Manager bookings and events
+ * Version:           1.1.1
  * Author:            KoenG
  * Text Domain:       as-em-search
  * Domain Path:       /languages

--- a/as-em-search.php
+++ b/as-em-search.php
@@ -46,11 +46,18 @@ function as_em_search_show_form(){
 function as_em_search( $search_term ) {
     global $wpdb;
     $table_name = EM_BOOKINGS_TABLE;
-
-    $query = $wpdb->prepare(
-        "SELECT booking_id, event_id, booking_spaces, booking_meta FROM $table_name WHERE booking_meta LIKE %s ORDER BY event_id",
-        '%' . $search_term . '%'
-    );
+    $events_tbl = EM_EVENTS_TABLE;
+    $blog_id = get_current_blog_id();
+    $sql = <<<EOD
+SELECT b.booking_id, b.event_id, b.booking_spaces, booking_status, b.booking_meta, b.booking_date 
+    FROM $table_name b
+    INNER JOIN $events_tbl e on b.event_id = e.event_id
+    WHERE b.booking_meta LIKE %s 
+    AND e.blog_id = %d
+    ORDER BY b.event_id, b.booking_date desc
+    LIMIT 101
+EOD;
+    $query = $wpdb->prepare($sql, '%' . $search_term . '%', $blog_id);
 
     return $wpdb->get_results($query) ;
 }

--- a/as-em-search.php
+++ b/as-em-search.php
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:       AS EM Search
  * Description:       Makes it possible to search in Events Manager bookings and events
- * Version:           1.1.1
+ * Version:           1.1.2
  * Author:            KoenG
  * Text Domain:       as-em-search
  * Domain Path:       /languages
@@ -27,6 +27,20 @@ if ( ! defined( 'WPINC' ) ) {
 add_filter('em_create_events_submenu', 'as_em_search_admin_menu');
 
 function as_em_search_admin_menu($plugin_pages){
+    // first check if current user has custom capability 'as_em_search'
+    if (current_user_can( 'as_em_search' )) {
+        $plugin_pages['search_form'] =
+        add_submenu_page(
+            'edit.php?post_type='.EM_POST_TYPE_EVENT,
+            __('Search bookings','as-em-search'),
+            __('Search bookings','as-em-search'),
+            'as_em_search',
+            "events-manager-search-form",
+            'as_em_search_show_form'
+        );
+        return $plugin_pages;
+    }
+    // fall back to the default 'list_users' capability
     $plugin_pages['search_form'] =
         add_submenu_page(
             'edit.php?post_type='.EM_POST_TYPE_EVENT,

--- a/as-em-search.php
+++ b/as-em-search.php
@@ -12,7 +12,7 @@
  * @wordpress-plugin
  * Plugin Name:       AS EM Search
  * Description:       Makes it possible to search in Events Manager bookings and events
- * Version:           1.1.2
+ * Version:           1.1.3
  * Author:            KoenG
  * Text Domain:       as-em-search
  * Domain Path:       /languages
@@ -68,7 +68,7 @@ SELECT b.booking_id, b.event_id, b.booking_spaces, booking_status, b.booking_met
     INNER JOIN $events_tbl e on b.event_id = e.event_id
     WHERE b.booking_meta LIKE %s 
     AND e.blog_id = %d
-    ORDER BY b.event_id, b.booking_date desc
+    ORDER BY e.event_start desc, b.event_id desc, b.booking_date desc
     LIMIT 101
 EOD;
     $query = $wpdb->prepare($sql, '%' . $search_term . '%', $blog_id);
@@ -76,13 +76,13 @@ EOD;
     return $wpdb->get_results($query) ;
 }
 
-function as_em_get_event_name( $event_id ) {
+function as_em_get_event_info( $event_id ) {
     global $wpdb;
 
-    $query = $wpdb->prepare('SELECT event_name FROM ' . EM_EVENTS_TABLE . ' WHERE event_id = %d', $event_id);
+    $query = $wpdb->prepare('SELECT event_name, event_start_date, event_start_time, event_start FROM ' . EM_EVENTS_TABLE . ' WHERE event_id = %d', $event_id);
     $event = $wpdb->get_row($query, ARRAY_A);
 
-    return $event['event_name'];
+    return $event;
 }
 
 function as_em_search_load_plugin_textdomain() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: (this should be a list of wordpress.org userid's)
 Donate link: http://example.com/
 Tags: search, bookings, events, find
 Requires at least: 4.0
-Tested up to: 4.0
-Stable tag: 1.0.0
+Tested up to: 5.4.1
+Stable tag: 1.0.1
 License: The MIT License (MIT)
 License URI: http://opensource.org/licenses/MIT
 
@@ -42,3 +42,14 @@ Yes.
 = How do I get support? =
 
 Please post an issue in the github issue tracker.
+
+== Changelog ==
+ 
+= 1.0.1 =
+* Added 'Booking Date' and 'Booking Status' to the results columns.
+* Multisite compatibility: will search the current site only.
+* Limit results to first 100 records (sorted by most recent booking date first).
+* Added standard WP formatting to results.
+ 
+= 1.0.0 =
+* Original version

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://example.com/
 Tags: search, bookings, events, find
 Requires at least: 4.0
 Tested up to: 5.4.1
-Stable tag: 1.0.1
+Stable tag: 1.1.1
 License: The MIT License (MIT)
 License URI: http://opensource.org/licenses/MIT
 
@@ -45,12 +45,12 @@ Please post an issue in the github issue tracker.
 
 == Changelog ==
  
-= 1.0.1 =
+= 1.1.1 =
 * Added 'Booking Date', 'Booking Status', and 'Country' to the results columns.
 * Multisite compatibility: will search the current site only.
 * Limit results to first 100 records (sorted by most recent booking date first).
 * Added a simple help prompt and "no results" message.
 * Added standard WP formatting to results.
  
-= 1.0.0 =
+= 1.1.0 =
 * Original version

--- a/readme.txt
+++ b/readme.txt
@@ -46,9 +46,10 @@ Please post an issue in the github issue tracker.
 == Changelog ==
  
 = 1.0.1 =
-* Added 'Booking Date' and 'Booking Status' to the results columns.
+* Added 'Booking Date', 'Booking Status', and 'Country' to the results columns.
 * Multisite compatibility: will search the current site only.
 * Limit results to first 100 records (sorted by most recent booking date first).
+* Added a simple help prompt and "no results" message.
 * Added standard WP formatting to results.
  
 = 1.0.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://example.com/
 Tags: search, bookings, events, find
 Requires at least: 4.0
 Tested up to: 5.4.1
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: The MIT License (MIT)
 License URI: http://opensource.org/licenses/MIT
 
@@ -43,8 +43,13 @@ Yes.
 
 Please post an issue in the github issue tracker.
 
+
 == Changelog ==
  
+= 1.1.3 =
+* Sort events by most recent first.
+* Improve event name formatting, and include start date and time.
+
 = 1.1.2 =
 * Added permissions check for custom 'as_em_search' capability.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://example.com/
 Tags: search, bookings, events, find
 Requires at least: 4.0
 Tested up to: 5.4.1
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: The MIT License (MIT)
 License URI: http://opensource.org/licenses/MIT
 
@@ -45,6 +45,9 @@ Please post an issue in the github issue tracker.
 
 == Changelog ==
  
+= 1.1.2 =
+* Added permissions check for custom 'as_em_search' capability.
+
 = 1.1.1 =
 * Added 'Booking Date', 'Booking Status', and 'Country' to the results columns.
 * Multisite compatibility: will search the current site only.

--- a/search-form.php
+++ b/search-form.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WPINC' ) ) {
         $search_results = null;
     }
 ?>
-<div><?php _e('Search bookings','as-em-search');?></div>
+<h1><?php _e('Search bookings','as-em-search');?></h1>
 <form method="get">
     <input type="hidden" name="post_type" value="<?php echo EM_POST_TYPE_EVENT;?>">
     <input type="hidden" name="page" value="events-manager-search-form">
@@ -21,7 +21,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 <div>
     <?php if( null != $search_results ): ?>
-        <table>
+        <table class="wp-list-table widefat fixed striped pages">
             <thead>
                 <tr>
                     <th><?php _e('Name', 'as-em-search');?></th>
@@ -29,6 +29,8 @@ if ( ! defined( 'WPINC' ) ) {
                     <th><?php _e('City','as-em-search');?></th>
                     <th><?php _e('Phone','as-em-search');?></th>
                     <th><?php _e('Spaces','as-em-search');?></th>
+                    <th><?php _e('Booked On','as-em-search');?></th>
+                    <th><?php _e('Status','as-em-search');?></th>
                 </tr>
             </thead>
             <tbody>
@@ -44,7 +46,7 @@ if ( ! defined( 'WPINC' ) ) {
                         $event_name = as_em_get_event_name( $event_id );
                     ?>
                     <tr>
-                        <td colspan="5"><?php echo $event_name;?></td>
+                        <td colspan="7"><?php echo $event_name;?></td>
                     </tr>
                 <?php endif;?>
                 <tr>
@@ -71,8 +73,19 @@ if ( ! defined( 'WPINC' ) ) {
                     <td>
                         <?php echo $result->booking_spaces;?>
                     </td>
+                    <td>
+                        <?php echo $result->booking_date;?>
+                    </td>
+                    <td>
+                        <?php echo $result->booking_status;?>
+                    </td>
                 </tr>
             <?php endforeach;?>
+            <?php if( count($search_results) > 100 ):?>
+                <tr>
+                    <td colspan="7">Only first 100 results are shown</td>
+                </tr>
+            <?php endif;?>
             </tbody>
         </table>
     <?php endif; ?>

--- a/search-form.php
+++ b/search-form.php
@@ -51,10 +51,13 @@ if ( ! defined( 'WPINC' ) ) {
                 <?php if( $event_id != $result->event_id ):?>
                     <?php
                         $event_id = $result->event_id;
-                        $event_name = as_em_get_event_name( $event_id );
+                        $event_info = as_em_get_event_info( $event_id );
                     ?>
                     <tr>
-                        <td colspan="8"><?php echo $event_name;?></td>
+                        <td colspan="3" class="as_evtname"><h3><?php echo $event_info['event_name'];?></h3></td>
+                        <td colspan="5" style="vertical-align:middle;" class="as_evtstart">
+                            starts on: <?php echo $event_info['event_start_date'].' '.$event_info['event_start_time'].' (local) / '.$event_info['event_start'].' UTC';?>
+                        </td>
                     </tr>
                 <?php endif;?>
                 <tr>
@@ -94,7 +97,7 @@ if ( ! defined( 'WPINC' ) ) {
             <?php endforeach;?>
             <?php if( count($search_results) > 100 ):?>
                 <tr>
-                    <td colspan="8">Only first 100 results are shown</td>
+                    <td colspan="8">Only the first 100 results are shown</td>
                 </tr>
             <?php endif;?>
             </tbody>
@@ -102,6 +105,6 @@ if ( ! defined( 'WPINC' ) ) {
     <?php elseif( ! empty( $_GET ) && isset( $_GET['as_em_search'] ) ): ?>
         <p>No results for "<?php echo $_GET['as_em_search']?>".</p>
     <?php else: ?>
-        <p>Enter your search term above.&nbsp; Up to 100 rows are returned in descending booking date order.</p>
+        <p>Enter your search term above.&nbsp; Up to 100 rows are returned, sorted by most recent events and most recent bookings first.</p>
     <?php endif; ?>
 </div>

--- a/search-form.php
+++ b/search-form.php
@@ -10,6 +10,13 @@ if ( ! defined( 'WPINC' ) ) {
     } else {
         $search_results = null;
     }
+    $as_em_status_array = array(
+        0 => 'Pending',
+        1 => 'Approved',
+        2 => 'Rejected',
+        3 => 'Cancelled',
+        4 => 'Awaiting Payment'
+    );
 ?>
 <h1><?php _e('Search bookings','as-em-search');?></h1>
 <form method="get">
@@ -27,6 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
                     <th><?php _e('Name', 'as-em-search');?></th>
                     <th><?php _e('Email', 'as-em-search');?></th>
                     <th><?php _e('City','as-em-search');?></th>
+                    <th><?php _e('Country','as-em-search');?></th>
                     <th><?php _e('Phone','as-em-search');?></th>
                     <th><?php _e('Spaces','as-em-search');?></th>
                     <th><?php _e('Booked On','as-em-search');?></th>
@@ -46,7 +54,7 @@ if ( ! defined( 'WPINC' ) ) {
                         $event_name = as_em_get_event_name( $event_id );
                     ?>
                     <tr>
-                        <td colspan="7"><?php echo $event_name;?></td>
+                        <td colspan="8"><?php echo $event_name;?></td>
                     </tr>
                 <?php endif;?>
                 <tr>
@@ -68,6 +76,9 @@ if ( ! defined( 'WPINC' ) ) {
                         <?php echo $meta['dbem_city'];?>
                     </td>
                     <td>
+                        <?php echo $meta['dbem_country'];?>
+                    </td>
+                    <td>
                         <?php echo $meta['dbem_phone'];?>
                     </td>
                     <td>
@@ -77,16 +88,20 @@ if ( ! defined( 'WPINC' ) ) {
                         <?php echo $result->booking_date;?>
                     </td>
                     <td>
-                        <?php echo $result->booking_status;?>
+                        <?php echo ($result->booking_status < 4 ? $as_em_status_array[$result->booking_status] : "Awaiting Payment (#$result->booking_status)"); ?>
                     </td>
                 </tr>
             <?php endforeach;?>
             <?php if( count($search_results) > 100 ):?>
                 <tr>
-                    <td colspan="7">Only first 100 results are shown</td>
+                    <td colspan="8">Only first 100 results are shown</td>
                 </tr>
             <?php endif;?>
             </tbody>
         </table>
+    <?php elseif( ! empty( $_GET ) && isset( $_GET['as_em_search'] ) ): ?>
+        <p>No results for "<?php echo $_GET['as_em_search']?>".</p>
+    <?php else: ?>
+        <p>Enter your search term above.&nbsp; Up to 100 rows are returned in descending booking date order.</p>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
* Added 'Booking Date', 'Booking Status', and 'Country' to the results columns.
* Multisite compatibility: will search the current site only.
* Limit results to first 100 records (sorted by most recent booking date first).
* Added a simple help prompt and "no results" message.
* Added standard WP formatting to results.
* Incremented plugin version # to v.1.1.1.
This can close issue #1 